### PR TITLE
updated uglify-js due to vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "minimatch": "^3.0.1",
     "object-assign": "^2.0.0",
-    "uglify-js": "^2.4.16"
+    "uglify-js": "^2.6.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
[CVE-2015-8858](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8858)
High severity
The uglify-js package before 2.6.0 for Node.js allows attackers to cause a denial of service (CPU consumption) via cr...
package-lock.json update suggested: 
uglify-js ~> 2.6.0