### PR TITLE
chore(dev-deps): move coveralls installation to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ node_js:
   - "node"
 
 script:
-  - npm test
+  - npm run test-cov
 
 after_script:
+  - npm install coveralls
   - nyc report --reporter=text-lcov | coveralls

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Minify JavaScript files with UglifyJS.",
   "main": "index",
   "scripts": {
-    "test": "nyc mocha test/index.js",
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "test": "mocha test/index.js",
+    "test-cov": "nyc npm run test",
     "eslint": "eslint ."
   },
   "directories": {
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "coveralls": "^3.0.3",
     "eslint": "^6.1.0",
     "eslint-config-hexo": "3.0.0",
     "mocha": "^6.1.4",


### PR DESCRIPTION
Closes https://github.com/hexojs/hexo-uglify/pull/41

coveralls is not used as `require()`.