### PR TITLE
Fix error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ uglify:
   output:
   compress:
   exclude:
-    - *.min.js
+    - '*.min.js'
 ```
 
 - **exclude**: Exclude files. Use [glob expressions](https://github.com/micromatch/micromatch#extended-globbing) for path matching.


### PR DESCRIPTION
Double quotation marks are required here.
````
FATAL YAMLException: unidentified alias ".min.js" (119:17)

 116 |     output:
 117 |     compress:
 118 |     exclude:
 119 |       - *.min.js
````